### PR TITLE
DFL-3447 Browser JS has no longer a label in the JS dropdown in Scripts

### DIFF
--- a/src/ecma-debugger/templates.js
+++ b/src/ecma-debugger/templates.js
@@ -277,7 +277,7 @@
       var is_linked = script.script_type == "linked";
       ret = ["cst-option",
               ["span",
-                 script.filename,
+                 script.filename || script.uri,
                  "data-tooltip", is_linked && "js-script-select",
                  "data-tooltip-text", is_linked && script.uri]];
 


### PR DESCRIPTION
Regression caused by the fixes in the URI class, relative URIs no longer have a filename.
