### PR TITLE
Change console host command: $ → querySelector

### DIFF
--- a/src/repl/commandtransformer.js
+++ b/src/repl/commandtransformer.js
@@ -254,7 +254,7 @@ cls.HostCommandTransformer = function() {
   {
     if (this.is_global_call(tokenlist, index))
       token[VALUE] = "(typeof $ == 'function' && $ || \
-                       function(e) { return document.getElementById(e); })";
+                       function(e) { return document.querySelector(e); })";
   };
 
   this._hostcommands.$$ = function(token, tokenlist, index)

--- a/tests/commandtransformer.qunit.html
+++ b/tests/commandtransformer.qunit.html
@@ -76,11 +76,11 @@ test("dir/dirxml", function() {
 
 test("$", function() {
     equal(transform("$"), "$");
-    equal(transform("$(foo)"), "document.getElementById(foo)");
-    equal(transform("var x=$(foo)"), "var x=document.getElementById(foo)");
-    equal(transform("var x= $(foo)"), "var x= document.getElementById(foo)");
-    equal(transform("var x =$(foo)"), "var x =document.getElementById(foo)");
-    equal(transform("var x = $(foo)"), "var x = document.getElementById(foo)");
+    equal(transform("$(foo)"), "document.querySelector(foo)");
+    equal(transform("var x=$(foo)"), "var x=document.querySelector(foo)");
+    equal(transform("var x= $(foo)"), "var x= document.querySelector(foo)");
+    equal(transform("var x =$(foo)"), "var x =document.querySelector(foo)");
+    equal(transform("var x = $(foo)"), "var x = document.querySelector(foo)");
 
 });
 


### PR DESCRIPTION
This change to Firebug's Command Line API has been accepted by Firefox, Firebug,
and WebKit. Having the same API in Dragonfly would be great!

Firebug Command Line API: http://getfirebug.com/wiki/index.php/Command_Line_API.

https://bugzilla.mozilla.org/show_bug.cgi?id=778732
http://code.google.com/p/fbug/issues/detail?id=5764
https://bugs.webkit.org/show_bug.cgi?id=92648
