### PR TITLE
Display custom content-type content bodies in Network Display

### DIFF
--- a/src/network/network_details_templates.js
+++ b/src/network/network_details_templates.js
@@ -404,6 +404,7 @@ templates._request_body = function(req, do_raw)
       var type = cls.ResourceUtil.mime_to_type(req.request_body.mimeType);
       if (TEXT_TYPES.contains(type))
       {
+        var decoded = cls.ResourceUtil.decode_string_content(req.request_body.content.stringData);
         ret = req.request_body.content.stringData;
       }
       else
@@ -460,7 +461,8 @@ templates._response_body = function(resp, do_raw, is_last_response)
       // Attempt to display the responsebody.
       if (TEXT_TYPES.contains(resp.logger_entry_type))
       {
-        ret.push(this._pre(resp.responsebody.content.stringData));
+        var decoded = cls.ResourceUtil.decode_string_content(resp.responsebody.content.stringData);
+        ret.push(this._pre(decoded));
       }
       else if (resp.logger_entry_type == "image")
       {

--- a/src/resource-manager/resource_util.js
+++ b/src/resource-manager/resource_util.js
@@ -30,6 +30,16 @@ cls.ResourceUtil.bytes_to_human_readable = function(bytes)
   }
 }
 
+cls.ResourceUtil.decode_string_content = function(data) {
+  if (/^data:/.test(data)){
+    var dataStart = data.indexOf(',');
+    var is_base64 = data.lastIndexOf(";base64", dataStart) != -1;
+    data = is_base64 ? decodeURIComponent(escape(atob(data.slice(dataStart + 1)))) : decodeURIComponent(data.slice(dataStart + 1));
+  }
+
+  return data;
+}
+
 /**
  * Common extensions mapped to generic type strings
  */
@@ -176,13 +186,18 @@ cls.ResourceUtil.type_to_content_mode = function(type)
   return "text";
 }
 
+cls.ResourceUtil._strip_mime_custom_field = function(mime)
+{
+  return mime.replace(/[^\/]+\+/, '');
+}
+
 cls.ResourceUtil.mime_to_type = function(mime, extension)
 {
   if (mime)
   {
-    return this.mime_type_map[mime.contains(";") ?
-                              mime.split(";")[0].trim() :
-                              mime];
+    mime = mime.contains(";") ?  mime.split(";")[0].trim() : mime
+    mime = this._strip_mime_custom_field(mime);
+    return this.mime_type_map[mime];
   }
 }
 


### PR DESCRIPTION
See issue [#153 Network details doesn't display custom content-type body](https://github.com/operasoftware/dragonfly/issues/153)

I also noticed that some content bodies were displayed starting as `data:application/json;base64,` and then followed by the encoded content. I added in the potential base64 decoding prior to the display in the view as well.

I wasn't sure what the policy was on unit test suite maintenance, so I have not submitted my unit tests in this pull request.

Please let me know if this feature is already completed, in-progress, or acceptable in this form :)
