### PR TITLE
Fix building CSS around non-ascii symbols

### DIFF
--- a/tools/dfbuild.py
+++ b/tools/dfbuild.py
@@ -455,7 +455,7 @@ def _convert_imgs_to_data_uris(src):
                             temp.write(line.encode("ascii"))
                             dirty = True
                 else:
-                    temp.write(line.encode("ascii"))
+                    temp.write(line.encode("ascii", "xmlcharrefreplace"))
                     dirty = True
 
             if dirty:


### PR DESCRIPTION
I met some trouble when trying to build the Dragonfly under my Win7 64 bit. And this fix helps to build Dragonfly with incapsulated tool easy again.
